### PR TITLE
docs: replace faulty link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Access the app on `http://localhost:3000/`.
 
 [Security Policies and Procedures](./docs/SECURITY)
 
-[License](./LICENSE)
+[License](./LICENSE.md)
 
 ## Netlify Integration
 


### PR DESCRIPTION
## Description and Motivation


Fixed a faulty link to License within the Contribution section.




## Checklist:



- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-frontend/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `yarn lint`.
- [x] The project builds and is able to deploy on Netlify `yarn build`.
