### PR TITLE
feat(docker): Multistage docker file for small images to host elsewhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,38 @@
-FROM node:alpine
-# Note for future, this dockerfile is not very efficient 
-# We can improve this massively by: 
-# 1. Using a multi-stage build to reduce the size of the image
-# 2. Using a smaller base image, such as alpine
-# 3. Using standalone option in NextJS to only build the files needed for production to be run with server.js 
-# Dont have time for this now but good to note a natural evolution of this dockerfile
-RUN mkdir -p /usr/src/app
+# Author : @0xFable
+# This is a 3 step Dockerfile used to build and run the application in the smallest manner for deployments 
+# It is based on the official Next.js Dockerfile and the official Node.js Dockerfile
+# It is not used for development purposes but with github CI images are made which can be used to deploy our frontend elsewhere easily
+# The deployment is broken into 3 stages: 
+# 1. Install dependencies 
+# 2. Build the app using the installed dependencies
+# 3. Run the app. For this all the build artifacts needed are copied in 
+# While a basic single image doing all steps will work its massive (over 5gb for a frontend)
+# The final image in this case is very small and can be used to deploy the app easily (800mb or less)
+FROM node:18-alpine AS deps
 RUN apk add --no-cache libc6-compat python3 make g++
-ENV PORT 3000
+WORKDIR /app
+COPY package*.json .
+ARG NODE_ENV
+ENV NODE_ENV $NODE_ENV
+RUN npm install
 
-WORKDIR /usr/src/app
+# Stage 2: build the app using the installed dependencies
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
 
-COPY package.json /usr/src/app
-COPY yarn.lock /usr/src/app
-
-# Production use node instead of root
-# USER node
-
-RUN yarn install --production
-
-COPY . /usr/src/app
-
-# RUN yarn build
+# Stage 3: copy the build artifacts and run the app
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/next.config.js /app/next-env.d.ts /app/tsconfig.json ./
+RUN npm install next
 
 EXPOSE 3000
-CMD [ "yarn", "dev" ]
+
+ENTRYPOINT ["npm", "run", "start"]

--- a/next.config.js
+++ b/next.config.js
@@ -69,6 +69,9 @@ const config = {
     // !! WARN !!
     ignoreBuildErrors: true,
   },
+  experimental: {
+    outputStandalone: true,
+  },
   eslint: {
     // Warning: This allows production builds to successfully complete even if
     // your project has ESLint errors.


### PR DESCRIPTION
## Description and Motivation
The result from this PR is a dockerimage we build which is much smaller and easier to deploy with. 
Wont be deployed until after this is merged and we cut a release. Then the CI will make our new smaller images :D 

We use experimental feature 'outputStandalone' to give us a standalone bundle of files we can host the app from. This is needed for things hosting on Github Pages or Akash. 