### PR TITLE
chore: set injectiveClient null if direct signer not available

### DIFF
--- a/components/Pages/Dashboard/BondingActions/hooks/bondTokens.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/bondTokens.ts
@@ -10,11 +10,11 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const bondTokens: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient | null,
   address: string,
   amount: number,
   denom: string,
   config: Config,
+  injectiveSigningClient?: InjectiveSigningStargateClient
 ) => {
   const handleMsg = {
     bond: {

--- a/components/Pages/Dashboard/BondingActions/hooks/bondTokens.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/bondTokens.ts
@@ -10,7 +10,7 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const bondTokens: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient,
+  injectiveSigningClient: InjectiveSigningStargateClient | null,
   address: string,
   amount: number,
   denom: string,
@@ -38,7 +38,7 @@ export const bondTokens: any = async (
       address, [execMsg], '',
     ) * 1.3)
     fee = await TerraTreasuryService.getInstance().getTerraClassicFee(execMsg.value.funds, gas)
-  } else if (await signingClient.getChainId() === ChainId.injective) {
+  } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const injectiveTxData = await getInjectiveTxData(
       injectiveSigningClient, address, [execMsg],
     )

--- a/components/Pages/Dashboard/BondingActions/hooks/claimRewards.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/claimRewards.ts
@@ -9,7 +9,7 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const claimRewards: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient,
+  injectiveSigningClient: InjectiveSigningStargateClient | null,
   address: string,
   config: Config,
 ) => {
@@ -27,7 +27,7 @@ export const claimRewards: any = async (
       address, [execMsg], '',
     ) * 1.3)
     fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-  } else if (await signingClient.getChainId() === ChainId.injective) {
+  } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const injectiveTxData = await getInjectiveTxData(
       injectiveSigningClient, address, [execMsg],
     )

--- a/components/Pages/Dashboard/BondingActions/hooks/claimRewards.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/claimRewards.ts
@@ -9,9 +9,9 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const claimRewards: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient | null,
   address: string,
   config: Config,
+  injectiveSigningClient?: InjectiveSigningStargateClient
 ) => {
   const handleMsg = {
     claim: {},

--- a/components/Pages/Dashboard/BondingActions/hooks/createNewEpoch.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/createNewEpoch.ts
@@ -9,7 +9,7 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const createNewEpoch: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient,
+  injectiveSigningClient: InjectiveSigningStargateClient | null,
   config: Config,
   address: string,
 ) => {
@@ -27,7 +27,7 @@ export const createNewEpoch: any = async (
       address, [execMsg], '',
     ) * 1.3)
     fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-  } else if (await signingClient.getChainId() === ChainId.injective) {
+  } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const injectiveTxData = await getInjectiveTxData(
       injectiveSigningClient, address, [execMsg],
     )

--- a/components/Pages/Dashboard/BondingActions/hooks/createNewEpoch.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/createNewEpoch.ts
@@ -9,9 +9,9 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const createNewEpoch: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient | null,
   config: Config,
   address: string,
+  injectiveSigningClient?: InjectiveSigningStargateClient
 ) => {
   const handleMsg = {
     new_epoch: {},

--- a/components/Pages/Dashboard/BondingActions/hooks/unbondTokens.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/unbondTokens.ts
@@ -9,7 +9,7 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const unbondTokens: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient,
+  injectiveSigningClient: InjectiveSigningStargateClient | null,
   address: string,
   amount: number,
   denom: string,
@@ -38,7 +38,7 @@ export const unbondTokens: any = async (
       address, [execMsg], '',
     ) * 1.3)
     fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-  } else if (await signingClient.getChainId() === ChainId.injective) {
+  } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const injectiveTxData = await getInjectiveTxData(
       injectiveSigningClient, address, [execMsg],
     )

--- a/components/Pages/Dashboard/BondingActions/hooks/unbondTokens.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/unbondTokens.ts
@@ -9,11 +9,11 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const unbondTokens: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient | null,
   address: string,
   amount: number,
   denom: string,
   config: Config,
+  injectiveSigningClient?: InjectiveSigningStargateClient
 ) => {
   const handleMsg = {
     unbond: {

--- a/components/Pages/Dashboard/BondingActions/hooks/useTransaction.tsx
+++ b/components/Pages/Dashboard/BondingActions/hooks/useTransaction.tsx
@@ -90,32 +90,32 @@ export const useTransaction = () => {
     if (data.bondingAction === ActionType.bond) {
       return await bondTokens(
         signingClient,
-        injectiveSigningClient,
         address,
         adjustedAmount,
         data.denom,
         config,
+        injectiveSigningClient
       )
     } else if (data.bondingAction === ActionType.unbond) {
       return await unbondTokens(
         signingClient,
-        injectiveSigningClient,
         address,
         adjustedAmount,
         data.denom,
         config,
+        injectiveSigningClient
       )
     } else if (data.bondingAction === ActionType.withdraw) {
       return await withdrawTokens(
-        signingClient, injectiveSigningClient, address, data.denom, config,
+        signingClient, address, data.denom, config, injectiveSigningClient
       )
     } else if (data.bondingAction === ActionType.claim) {
       return await claimRewards(
-        signingClient, injectiveSigningClient, address, config,
+        signingClient, address, config, injectiveSigningClient
       )
     } else {
       return await createNewEpoch(
-        signingClient, injectiveSigningClient, config, address,
+        signingClient, config, address, injectiveSigningClient
       )
     }
   },

--- a/components/Pages/Dashboard/BondingActions/hooks/useTransaction.tsx
+++ b/components/Pages/Dashboard/BondingActions/hooks/useTransaction.tsx
@@ -72,7 +72,7 @@ export const useTransaction = () => {
       }
     },
     {
-      enabled: txStep === TxStep.Idle && !error && Boolean(signingClient) && Boolean(injectiveSigningClient),
+      enabled: txStep === TxStep.Idle && !error && Boolean(signingClient),
       refetchOnWindowFocus: false,
       retry: false,
       staleTime: 0,

--- a/components/Pages/Dashboard/BondingActions/hooks/withdrawTokens.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/withdrawTokens.ts
@@ -9,10 +9,10 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const withdrawTokens: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient | null,
   address: string,
   denom: string,
   config: Config,
+  injectiveSigningClient?: InjectiveSigningStargateClient
 ) => {
   const handleMsg = {
     withdraw: {

--- a/components/Pages/Dashboard/BondingActions/hooks/withdrawTokens.ts
+++ b/components/Pages/Dashboard/BondingActions/hooks/withdrawTokens.ts
@@ -9,7 +9,7 @@ import { createExecuteMessage } from 'util/messages/createExecuteMessage'
 
 export const withdrawTokens: any = async (
   signingClient: SigningCosmWasmClient,
-  injectiveSigningClient: InjectiveSigningStargateClient,
+  injectiveSigningClient: InjectiveSigningStargateClient | null,
   address: string,
   denom: string,
   config: Config,
@@ -30,7 +30,7 @@ export const withdrawTokens: any = async (
       address, [execMsg], '',
     ) * 1.3)
     fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-  } else if (await signingClient.getChainId() === ChainId.injective) {
+  } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const injectiveTxData = await getInjectiveTxData(
       injectiveSigningClient, address, [execMsg],
     )

--- a/components/Pages/Flashloan/Vaults/hooks/executeVault.ts
+++ b/components/Pages/Flashloan/Vaults/hooks/executeVault.ts
@@ -13,7 +13,7 @@ type ExecuteAddLiquidityArgs = {
   senderAddress: string
   contractAddress: string
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   msgs: any
   encodedMsgs: any
 }
@@ -40,7 +40,7 @@ export const executeVault = async ({
 
   const funds = [coin(amount, denom)]
 
-  if (await signingClient.getChainId() === ChainId.injective) {
+  if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const execMsg = createExecuteMessage({ senderAddress,
       contractAddress,
       message: msgs })

--- a/components/Pages/Flashloan/Vaults/hooks/executeVault.ts
+++ b/components/Pages/Flashloan/Vaults/hooks/executeVault.ts
@@ -13,9 +13,9 @@ type ExecuteAddLiquidityArgs = {
   senderAddress: string
   contractAddress: string
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   msgs: any
   encodedMsgs: any
+  injectiveSigningClient?: InjectiveSigningStargateClient
 }
 
 export const executeVault = async ({

--- a/components/Pages/Flashloan/Vaults/hooks/useTransaction.tsx
+++ b/components/Pages/Flashloan/Vaults/hooks/useTransaction.tsx
@@ -15,7 +15,7 @@ type Params = {
   denom: string
   enabled: boolean
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   contractAddress: string
   msgs: any | null
@@ -80,7 +80,7 @@ export const useTransaction = ({
       }
       try {
         const isInjective = await signingClient.getChainId() === ChainId.injective
-        const response = isInjective ? await injectiveSigningClient?.simulate(
+        const response = isInjective && injectiveSigningClient ? await injectiveSigningClient?.simulate(
           senderAddress,
           debouncedMsgs,
           '',

--- a/components/Pages/Flashloan/Vaults/hooks/useTransaction.tsx
+++ b/components/Pages/Flashloan/Vaults/hooks/useTransaction.tsx
@@ -15,7 +15,6 @@ type Params = {
   denom: string
   enabled: boolean
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   contractAddress: string
   msgs: any | null
@@ -25,6 +24,7 @@ type Params = {
   estimateEnabled?: boolean
   tokenAAmount?: number
   tokenBAmount?: number
+  injectiveSigningClient?: InjectiveSigningStargateClient
   onBroadcasting?: (txHash: string) => void
   onSuccess?: (txHash: string, txInfo?: any) => void
   onError?: (txHash?: string, txInfo?: any) => void

--- a/components/Pages/Flashloan/Vaults/hooks/useTransaction.tsx
+++ b/components/Pages/Flashloan/Vaults/hooks/useTransaction.tsx
@@ -128,7 +128,6 @@ export const useTransaction = ({
         txStep === TxStep.Idle &&
         !error &&
         Boolean(signingClient) &&
-        Boolean(injectiveSigningClient) &&
         enabled,
       refetchOnWindowFocus: false,
       retry: false,

--- a/components/Pages/Flashloan/hooks/executeFlashloan.ts
+++ b/components/Pages/Flashloan/hooks/executeFlashloan.ts
@@ -9,7 +9,7 @@ type ExecuteFlashloanArgs = {
   senderAddress: string
   contractAddress: string
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   msgs: any
 }
 
@@ -20,7 +20,7 @@ export const executeFlashloan = async ({
   contractAddress,
   senderAddress,
 }: ExecuteFlashloanArgs): Promise<any> => {
-  if (await signingClient.getChainId() === ChainId.injective) {
+  if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const execMsg = createExecuteMessage({ senderAddress,
       contractAddress,
       message: msgs })

--- a/components/Pages/Flashloan/hooks/executeFlashloan.ts
+++ b/components/Pages/Flashloan/hooks/executeFlashloan.ts
@@ -9,16 +9,16 @@ type ExecuteFlashloanArgs = {
   senderAddress: string
   contractAddress: string
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   msgs: any
+  injectiveSigningClient?: InjectiveSigningStargateClient
 }
 
 export const executeFlashloan = async ({
   msgs,
   signingClient,
-  injectiveSigningClient,
   contractAddress,
   senderAddress,
+  injectiveSigningClient,
 }: ExecuteFlashloanArgs): Promise<any> => {
   if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const execMsg = createExecuteMessage({ senderAddress,

--- a/components/Pages/Flashloan/hooks/useFlashloan.ts
+++ b/components/Pages/Flashloan/hooks/useFlashloan.ts
@@ -26,7 +26,7 @@ const useFlashloan = ({ json }) => {
   }, [json, address, chainId])
 
   return useTransaction({
-    enabled: Boolean(signingClient) && Boolean(injectiveSigningClient) && Boolean(encodedMsgs),
+    enabled: Boolean(signingClient) && Boolean(encodedMsgs),
     msgs: json,
     signingClient,
     injectiveSigningClient,

--- a/components/Pages/Flashloan/hooks/useTransaction.tsx
+++ b/components/Pages/Flashloan/hooks/useTransaction.tsx
@@ -100,7 +100,6 @@ export const useTransaction = ({
         txStep === TxStep.Idle &&
         !error &&
         Boolean(signingClient) &&
-        Boolean(injectiveSigningClient) &&
         enabled,
       refetchOnWindowFocus: false,
       retry: false,

--- a/components/Pages/Flashloan/hooks/useTransaction.tsx
+++ b/components/Pages/Flashloan/hooks/useTransaction.tsx
@@ -14,7 +14,7 @@ import { executeFlashloan } from './executeFlashloan'
 type Params = {
   enabled: boolean
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   encodedMsgs: any | null
   contractAddress: string | undefined
@@ -54,7 +54,7 @@ export const useTransaction = ({
       }
       try {
         const isInjective = await signingClient.getChainId() === ChainId.injective
-        const response = isInjective ? await injectiveSigningClient?.simulate(
+        const response = isInjective && injectiveSigningClient ? await injectiveSigningClient?.simulate(
           senderAddress,
           debouncedMsgs,
           '',

--- a/components/Pages/Flashloan/hooks/useTransaction.tsx
+++ b/components/Pages/Flashloan/hooks/useTransaction.tsx
@@ -14,11 +14,11 @@ import { executeFlashloan } from './executeFlashloan'
 type Params = {
   enabled: boolean
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   encodedMsgs: any | null
   contractAddress: string | undefined
   msgs: any | null
+  injectiveSigningClient?: InjectiveSigningStargateClient
   onBroadcasting?: (txHash: string) => void
   onSuccess?: (txHash: string, txInfo?: any) => void
   onError?: (txHash?: string, txInfo?: any) => void
@@ -27,11 +27,11 @@ type Params = {
 export const useTransaction = ({
   enabled,
   signingClient,
-  injectiveSigningClient,
   senderAddress,
   encodedMsgs,
-  msgs,
   contractAddress,
+  msgs,
+  injectiveSigningClient,
   onBroadcasting,
   onSuccess,
   onError,
@@ -116,9 +116,9 @@ export const useTransaction = ({
   const { mutate } = useMutation(() => executeFlashloan({
     msgs,
     signingClient,
-    injectiveSigningClient,
     contractAddress,
     senderAddress,
+    injectiveSigningClient,
   }),
   {
     onMutate: () => {

--- a/components/Pages/Trade/Incentivize/hooks/useClosePosition.ts
+++ b/components/Pages/Trade/Incentivize/hooks/useClosePosition.ts
@@ -69,7 +69,7 @@ export const useClosePosition = ({ poolId }: OpenPosition) => {
           address, msg, '',
         ) * 1.3)
         fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-      } else if (await signingClient.getChainId() === ChainId.injective) {
+      } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
         const injectiveTxData = await getInjectiveTxData(
           injectiveSigningClient, address, msg,
         )

--- a/components/Pages/Trade/Incentivize/hooks/useOpenFlow.ts
+++ b/components/Pages/Trade/Incentivize/hooks/useOpenFlow.ts
@@ -135,7 +135,7 @@ export const useOpenFlow = ({ poolId, token, startDate, endDate }: Props) => {
         ) * 1.3)
         const funds = msgs.flatMap((elem) => elem.value.funds)
         fee = await TerraTreasuryService.getInstance().getTerraClassicFee(funds, gas)
-      } else if (await signingClient.getChainId() === ChainId.injective) {
+      } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
         const injectiveTxData = await getInjectiveTxData(
           injectiveSigningClient, address, msgs,
         )

--- a/components/Pages/Trade/Liquidity/hooks/useClaim.ts
+++ b/components/Pages/Trade/Liquidity/hooks/useClaim.ts
@@ -44,7 +44,7 @@ export const useClaim = ({ poolId }: Props) => {
           address, [msg], '',
         ) * 1.3)
         fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-      } else if (await signingClient.getChainId() === ChainId.injective) {
+      } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
         const injectiveTxData = await getInjectiveTxData(
           injectiveSigningClient, address, [msg],
         )

--- a/components/Pages/Trade/Liquidity/hooks/useClosePosition.ts
+++ b/components/Pages/Trade/Liquidity/hooks/useClosePosition.ts
@@ -55,7 +55,7 @@ export const useClosePosition = ({ poolId }: OpenPosition) => {
           address, msgs, '',
         ) * 1.3)
         fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-      } else if (await signingClient.getChainId() === ChainId.injective) {
+      } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
         const injectiveTxData = await getInjectiveTxData(
           injectiveSigningClient, address, msgs,
         )

--- a/components/Pages/Trade/Liquidity/hooks/useDepositTransaction.tsx
+++ b/components/Pages/Trade/Liquidity/hooks/useDepositTransaction.tsx
@@ -16,7 +16,6 @@ type Params = {
   swapAssets?: any[]
   price?: number
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   msgs: any | null
   encodedMsgs: any | null
@@ -24,6 +23,7 @@ type Params = {
   estimateEnabled?: boolean
   tokenAAmount?: string
   tokenBAmount?: string
+  injectiveSigningClient?: InjectiveSigningStargateClient
   onBroadcasting?: (txHash: string) => void
   onSuccess?: (txHash: string, txInfo?: any) => void
   onError?: (txHash?: string, txInfo?: any) => void

--- a/components/Pages/Trade/Liquidity/hooks/useDepositTransaction.tsx
+++ b/components/Pages/Trade/Liquidity/hooks/useDepositTransaction.tsx
@@ -16,7 +16,7 @@ type Params = {
   swapAssets?: any[]
   price?: number
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   msgs: any | null
   encodedMsgs: any | null
@@ -62,7 +62,7 @@ export const useTransaction: any = ({
       try {
         const isInjective = await signingClient.getChainId() === ChainId.injective
 
-        const response = isInjective ? await injectiveSigningClient?.simulate(
+        const response = isInjective && injectiveSigningClient ? await injectiveSigningClient?.simulate(
           senderAddress,
           debouncedMsgs,
           '',

--- a/components/Pages/Trade/Liquidity/hooks/useDepositTransaction.tsx
+++ b/components/Pages/Trade/Liquidity/hooks/useDepositTransaction.tsx
@@ -118,7 +118,6 @@ export const useTransaction: any = ({
         txStep === TxStep.Idle &&
         !error &&
         Boolean(signingClient) &&
-        Boolean(injectiveSigningClient) &&
         Boolean(senderAddress) &&
         enabled &&
         Boolean(swapAddress) &&

--- a/components/Pages/Trade/Liquidity/hooks/useForceEpochAndTakingSnapshots.ts
+++ b/components/Pages/Trade/Liquidity/hooks/useForceEpochAndTakingSnapshots.ts
@@ -88,7 +88,7 @@ const useForceEpochAndTakingSnapshots = ({
           address, msgs, '',
         ) * 1.3)
         fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-      } else if (await signingClient.getChainId() === ChainId.injective) {
+      } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
         const injectiveTxData = await getInjectiveTxData(
           injectiveSigningClient, address, msgs,
         )

--- a/components/Pages/Trade/Liquidity/hooks/useWithdrawPosition.ts
+++ b/components/Pages/Trade/Liquidity/hooks/useWithdrawPosition.ts
@@ -42,7 +42,7 @@ export const useWithdrawPosition = ({ poolId }) => {
           address, msgs, '',
         ) * 1.3)
         fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-      } else if (await signingClient.getChainId() === ChainId.injective) {
+      } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
         const injectiveTxData = await getInjectiveTxData(
           injectiveSigningClient, address, msgs,
         )

--- a/components/Pages/Trade/Liquidity/hooks/useWithdrawTransaction.tsx
+++ b/components/Pages/Trade/Liquidity/hooks/useWithdrawTransaction.tsx
@@ -15,7 +15,6 @@ import { getInjectiveTxData } from 'util/injective'
 type Params = {
   enabled: boolean
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   msgs: any | null
   encodedMsgs: any | null
@@ -24,6 +23,7 @@ type Params = {
   onSuccess?: (txHash: string, txInfo?: any) => void
   onError?: (txHash?: string, txInfo?: any) => void
   isNative?: boolean
+  injectiveSigningClient?: InjectiveSigningStargateClient
 }
 
 export const useWithdrawTransaction: any = ({

--- a/components/Pages/Trade/Liquidity/hooks/useWithdrawTransaction.tsx
+++ b/components/Pages/Trade/Liquidity/hooks/useWithdrawTransaction.tsx
@@ -95,7 +95,6 @@ export const useWithdrawTransaction: any = ({
         txStep === TxStep.Idle &&
         !error &&
         Boolean(signingClient) &&
-        Boolean(injectiveSigningClient) &&
         Number(amount) > 0 &&
         enabled,
       refetchOnWindowFocus: false,
@@ -208,7 +207,7 @@ export const useWithdrawTransaction: any = ({
       return await signingClient.getTx(txHash)
     },
     {
-      enabled: Boolean(txHash) && Boolean(signingClient) && Boolean(injectiveSigningClient),
+      enabled: Boolean(txHash) && Boolean(signingClient),
       retry: true,
     },
   )

--- a/components/Pages/Trade/Liquidity/hooks/useWithdrawTransaction.tsx
+++ b/components/Pages/Trade/Liquidity/hooks/useWithdrawTransaction.tsx
@@ -15,7 +15,7 @@ import { getInjectiveTxData } from 'util/injective'
 type Params = {
   enabled: boolean
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   msgs: any | null
   encodedMsgs: any | null
@@ -57,7 +57,7 @@ export const useWithdrawTransaction: any = ({
       }
       try {
         const isInjective = await signingClient.getChainId() === ChainId.injective
-        const response = isInjective ? await injectiveSigningClient?.simulate(
+        const response = isInjective && injectiveSigningClient ? await injectiveSigningClient?.simulate(
           senderAddress,
           debouncedMsgs,
           '',
@@ -117,7 +117,7 @@ export const useWithdrawTransaction: any = ({
         senderAddress, debouncedMsgs, '',
       ) * 1.3)
       fee = await TerraTreasuryService.getInstance().getTerraClassicFee(null, gas)
-    } else if (await signingClient.getChainId() === ChainId.injective) {
+    } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
       const injectiveTxData = await getInjectiveTxData(
         injectiveSigningClient, senderAddress, debouncedMsgs,
       )

--- a/components/Pages/Trade/Swap/hooks/directTokenSwap.ts
+++ b/components/Pages/Trade/Swap/hooks/directTokenSwap.ts
@@ -20,7 +20,7 @@ type DirectTokenSwapArgs = {
   signingClient: SigningCosmWasmClient
   msgs: Record<string, any>
   chainId?: string
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
 }
 
 export const directTokenSwap = async ({
@@ -62,7 +62,7 @@ export const directTokenSwap = async ({
       senderAddress, [execMsg], '',
     ) * 1.3)
     fee = await TerraTreasuryService.getInstance().getTerraClassicFee(execMsg.value.funds, gas)
-  } else if (await signingClient.getChainId() === ChainId.injective) {
+  } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const injectiveTxData = await getInjectiveTxData(
       injectiveSigningClient, senderAddress, [execMsg],
     )

--- a/components/Pages/Trade/Swap/hooks/directTokenSwap.ts
+++ b/components/Pages/Trade/Swap/hooks/directTokenSwap.ts
@@ -20,7 +20,7 @@ type DirectTokenSwapArgs = {
   signingClient: SigningCosmWasmClient
   msgs: Record<string, any>
   chainId?: string
-  injectiveSigningClient: InjectiveSigningStargateClient | null
+  injectiveSigningClient?: InjectiveSigningStargateClient
 }
 
 export const directTokenSwap = async ({

--- a/components/Pages/Trade/Swap/hooks/useTransaction.tsx
+++ b/components/Pages/Trade/Swap/hooks/useTransaction.tsx
@@ -16,7 +16,7 @@ type Params = {
   swapAssets: any[]
   price: number
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   msgs: any | null
   encodedMsgs: any | null
@@ -62,7 +62,7 @@ export const useTransaction = ({
       }
       try {
         const isInjective = await signingClient.getChainId() === ChainId.injective
-        const response = isInjective ? await injectiveSigningClient?.simulate(
+        const response = isInjective && injectiveSigningClient ? await injectiveSigningClient?.simulate(
           senderAddress,
           debouncedMsgs,
           '',

--- a/components/Pages/Trade/Swap/hooks/useTransaction.tsx
+++ b/components/Pages/Trade/Swap/hooks/useTransaction.tsx
@@ -16,13 +16,13 @@ type Params = {
   swapAssets: any[]
   price: number
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   msgs: any | null
   encodedMsgs: any | null
   amount: string
   gasAdjustment?: number
   estimateEnabled?: boolean
+  injectiveSigningClient?: InjectiveSigningStargateClient
   onBroadcasting?: (txHash: string) => void
   onSuccess?: (txHash: string, txInfo?: any) => void
   onError?: (txHash?: string, txInfo?: any) => void

--- a/hooks/useClients.ts
+++ b/hooks/useClients.ts
@@ -36,11 +36,15 @@ export const useClients = (walletChainName: string) => {
     }, {
       queryKey: ['injectiveSigningClient'],
       queryFn: async () => {
-        const offlineSigner : any = await getOfflineSignerDirect();
-        const client = await InjectiveStargate.InjectiveSigningStargateClient.connectWithSigner('https://sentry.tm.injective.network:443',
-          offlineSigner)
-        client.registry.register('/cosmwasm.wasm.v1.MsgExecuteContract', MsgExecuteContract)
-        return client
+        try {
+          const offlineSigner : any = await getOfflineSignerDirect();
+          const client = await InjectiveStargate.InjectiveSigningStargateClient.connectWithSigner('https://sentry.tm.injective.network:443',
+            offlineSigner)
+          client.registry.register('/cosmwasm.wasm.v1.MsgExecuteContract', MsgExecuteContract)
+          return client
+        } catch {
+          return null
+        }
       },
       enabled: isWalletConnected,
     },

--- a/hooks/useSimulate.ts
+++ b/hooks/useSimulate.ts
@@ -12,10 +12,10 @@ import { parseError } from 'util/parseError'
 type Simulate = {
   msgs: EncodeObject[]
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   address: string | undefined
   connected: boolean
   amount: string
+  injectiveSigningClient?: InjectiveSigningStargateClient
   onError?: (error: Error) => void
   onSuccess?: (data: any) => void
 }

--- a/hooks/useSimulate.ts
+++ b/hooks/useSimulate.ts
@@ -12,7 +12,7 @@ import { parseError } from 'util/parseError'
 type Simulate = {
   msgs: EncodeObject[]
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   address: string | undefined
   connected: boolean
   amount: string
@@ -53,7 +53,7 @@ const useSimulate = ({
         buttonLabel: null,
       })
       const isInjective = await signingClient.getChainId() === ChainId.injective
-      return isInjective ? injectiveSigningClient?.simulate(
+      return isInjective && injectiveSigningClient ? injectiveSigningClient?.simulate(
         address, msgs, null,
       ) : signingClient?.simulate(
         address, msgs, null,

--- a/hooks/useTransaction.tsx
+++ b/hooks/useTransaction.tsx
@@ -16,13 +16,13 @@ type Params = {
   swapAddress: string
   swapAssets: any[]
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   msgs: any | null
   encodedMsgs: any | null
   amount: string
   gasAdjustment?: number
   estimateEnabled?: boolean
+  injectiveSigningClient?: InjectiveSigningStargateClient
   onBroadcasting?: (txHash: string) => void
   onSuccess?: (txHash: string, txInfo?: any) => void
   onError?: (txHash?: string, txInfo?: any) => void

--- a/hooks/useTransaction.tsx
+++ b/hooks/useTransaction.tsx
@@ -16,7 +16,7 @@ type Params = {
   swapAddress: string
   swapAssets: any[]
   signingClient: SigningCosmWasmClient
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
   senderAddress: string
   msgs: any | null
   encodedMsgs: any | null
@@ -63,7 +63,7 @@ export const useTransaction = ({
       }
       try {
         const isInjective = await signingClient.getChainId() === ChainId.injective
-        const response = isInjective ? await injectiveSigningClient?.simulate(
+        const response = isInjective && injectiveSigningClient ? await injectiveSigningClient?.simulate(
           senderAddress,
           debouncedMsgs,
           '',

--- a/services/liquidity/executeAddLiquidity.ts
+++ b/services/liquidity/executeAddLiquidity.ts
@@ -11,7 +11,7 @@ type ExecuteAddLiquidityArgs = {
   senderAddress: string
   signingClient: SigningCosmWasmClient
   msgs: any
-  injectiveSigningClient: InjectiveSigningStargateClient
+  injectiveSigningClient: InjectiveSigningStargateClient | null
 }
 
 export const executeAddLiquidity = async ({
@@ -27,7 +27,7 @@ export const executeAddLiquidity = async ({
     ) * 1.3)
     const funds = msgs.flatMap((elem) => elem.value.funds)
     fee = await TerraTreasuryService.getInstance().getTerraClassicFee(funds, gas)
-  } else if (await signingClient.getChainId() === ChainId.injective) {
+  } else if (injectiveSigningClient && await signingClient.getChainId() === ChainId.injective) {
     const injectiveTxData = await getInjectiveTxData(
       injectiveSigningClient, senderAddress, msgs,
     )

--- a/services/liquidity/executeAddLiquidity.ts
+++ b/services/liquidity/executeAddLiquidity.ts
@@ -11,7 +11,7 @@ type ExecuteAddLiquidityArgs = {
   senderAddress: string
   signingClient: SigningCosmWasmClient
   msgs: any
-  injectiveSigningClient: InjectiveSigningStargateClient | null
+  injectiveSigningClient?: InjectiveSigningStargateClient
 }
 
 export const executeAddLiquidity = async ({


### PR DESCRIPTION

UseClients tries to create a injective signer even if the user does not want to interact with this chain. This PR returns null if the wallet can't provide a Direct Signer (like terra station)  for the injective client. The client is also not necessary to enable the buttons anymore
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-frontend/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

    Pull Requests targeted against the main branch will be auto-deployed on a separate preview URL

-->

- [ ] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-frontend/blob/main/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `yarn lint`.
- [ ] The project builds and is able to deploy on Netlify `yarn build`.
