### PR TITLE
fix: added error message for account not found on chain

### DIFF
--- a/util/parseError.ts
+++ b/util/parseError.ts
@@ -36,6 +36,10 @@ export const parseError = (error: Error) => {
       regex: /pending rewards to be claimed before you can execute this action/u,
       message: 'There are unclaimed rewards available. Claim first.',
     },
+    {
+      regex: /does not exist on chain\./u,
+      message: 'Current account does not exist on chain. Send some tokens there and please try again.',
+    },
   ]
 
   return (


### PR DESCRIPTION
## Description and Motivation

Added error message that is more descriptive for account not found on chain.

<img width="1028" alt="Screenshot 2024-03-01 at 4 03 16 PM" src="https://github.com/White-Whale-Defi-Platform/white-whale-frontend/assets/69917943/3c935643-09c4-4a8e-a9f5-9bed43f7b617">

## Related Issues

Resolves #517 
---

## Checklist:

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-frontend/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `yarn lint`.
- [x] The project builds and is able to deploy on Netlify `yarn build`.
